### PR TITLE
Use v 1.2.7 of openbanking commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,9 @@
     </modules>
 
     <properties>
-        <ob-clients.version>1.2.6</ob-clients.version>
-        <ob-common.version>1.2.6</ob-common.version>
-        <ob-auth.version>1.1.5</ob-auth.version>
+        <ob-clients.version>1.2.7</ob-clients.version>
+        <ob-common.version>1.2.7</ob-common.version>
+        <ob-auth.version>1.1.6</ob-auth.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
https://github.com/OpenBankingToolkit/openbanking-common/releases/tag/1.2.7

Fixes;
Serialisation is based on the value of the `iss` field of the software
statement, and the code expected OpenBanking iss to be "OpenBanking",
however in OB Directory Issued Software Statements the iss field is
actually "OpenBanking Ltd"

Issue: https://github.com/ForgeCloud/ob-deploy/issues/793