### PR TITLE
Create release 1.5.5

### DIFF
--- a/forgerock-openbanking-directory-client/pom.xml
+++ b/forgerock-openbanking-directory-client/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.5-SNAPSHOT</version>
+        <version>1.5.5</version>
     </parent>
 
 </project>

--- a/forgerock-openbanking-directory-client/pom.xml
+++ b/forgerock-openbanking-directory-client/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6-SNAPSHOT</version>
     </parent>
 
 </project>

--- a/forgerock-openbanking-directory-core/pom.xml
+++ b/forgerock-openbanking-directory-core/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.5-SNAPSHOT</version>
+        <version>1.5.5</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-directory-core/pom.xml
+++ b/forgerock-openbanking-directory-core/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-directory-sample/pom.xml
+++ b/forgerock-openbanking-directory-sample/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.5-SNAPSHOT</version>
+        <version>1.5.5</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-directory-sample/pom.xml
+++ b/forgerock-openbanking-directory-sample/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-directory-server/pom.xml
+++ b/forgerock-openbanking-directory-server/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.5-SNAPSHOT</version>
+        <version>1.5.5</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-directory-server/pom.xml
+++ b/forgerock-openbanking-directory-server/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Directory</name>
     <groupId>com.forgerock.openbanking.directory</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -110,7 +110,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-directory.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-directory.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/OpenBankingToolkit-directory.git</url>
-        <tag>1.5.5</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Directory</name>
     <groupId>com.forgerock.openbanking.directory</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-    <version>1.5.5-SNAPSHOT</version>
+    <version>1.5.5</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -110,7 +110,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-directory.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-directory.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/OpenBankingToolkit-directory.git</url>
-        <tag>HEAD</tag>
+        <tag>1.5.5</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
Use v 1.2.7 of openbanking commons 
https://github.com/OpenBankingToolkit/openbanking-common/releases/tag/1.2.7

Fixes;
Serialisation is based on the value of the `iss` field of the software
statement, and the code expected OpenBanking iss to be "OpenBanking",
however in OB Directory Issued Software Statements the iss field is
actually "OpenBanking Ltd"

Issue: https://github.com/ForgeCloud/ob-deploy/issues/793