### PR TITLE
793: Fix more issues with DirectorySoftwareStatement serialisation

### DIFF
--- a/forgerock-openbanking-directory-server/src/test/java/com/forgerock/openbanking/directory/api/softwarestatement/SoftwareStatementApiControllerIT.java
+++ b/forgerock-openbanking-directory-server/src/test/java/com/forgerock/openbanking/directory/api/softwarestatement/SoftwareStatementApiControllerIT.java
@@ -103,7 +103,8 @@ public class SoftwareStatementApiControllerIT {
 
                 // Then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(softwareStatement.getId()));
+                .andExpect(jsonPath("$.id").value(softwareStatement.getId()))
+                .andExpect(jsonPath("$.iss").value("ForgeRock"));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,9 @@
     </modules>
 
     <properties>
-        <ob-clients.version>1.2.8</ob-clients.version>
-        <ob-common.version>1.2.8</ob-common.version>
-        <ob-auth.version>1.1.7</ob-auth.version>
+        <ob-clients.version>1.2.9</ob-clients.version>
+        <ob-common.version>1.2.9</ob-common.version>
+        <ob-auth.version>1.1.8</ob-auth.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Use latest commons with fix to ensure `iss` field is visible in DirectorySoftwareStatement serialisation.
Also includes fix to add iss field to SoftwareStatement issued by the Directory Server.

Includes https://github.com/OpenBankingToolkit/openbanking-common/pull/140