### PR TITLE
Create release 1.5.7

### DIFF
--- a/forgerock-openbanking-directory-client/pom.xml
+++ b/forgerock-openbanking-directory-client/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.7-SNAPSHOT</version>
+        <version>1.5.7</version>
     </parent>
 
 </project>

--- a/forgerock-openbanking-directory-client/pom.xml
+++ b/forgerock-openbanking-directory-client/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.7</version>
+        <version>1.5.8-SNAPSHOT</version>
     </parent>
 
 </project>

--- a/forgerock-openbanking-directory-core/pom.xml
+++ b/forgerock-openbanking-directory-core/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.7-SNAPSHOT</version>
+        <version>1.5.7</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-directory-core/pom.xml
+++ b/forgerock-openbanking-directory-core/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.7</version>
+        <version>1.5.8-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-directory-sample/pom.xml
+++ b/forgerock-openbanking-directory-sample/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.7-SNAPSHOT</version>
+        <version>1.5.7</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-directory-sample/pom.xml
+++ b/forgerock-openbanking-directory-sample/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.7</version>
+        <version>1.5.8-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-directory-server/pom.xml
+++ b/forgerock-openbanking-directory-server/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.7-SNAPSHOT</version>
+        <version>1.5.7</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-directory-server/pom.xml
+++ b/forgerock-openbanking-directory-server/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.7</version>
+        <version>1.5.8-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Directory</name>
     <groupId>com.forgerock.openbanking.directory</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-    <version>1.5.7</version>
+    <version>1.5.8-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -110,7 +110,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-directory.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-directory.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/OpenBankingToolkit-directory.git</url>
-        <tag>1.5.7</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Directory</name>
     <groupId>com.forgerock.openbanking.directory</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-    <version>1.5.7-SNAPSHOT</version>
+    <version>1.5.7</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -110,7 +110,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-directory.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-directory.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/OpenBankingToolkit-directory.git</url>
-        <tag>HEAD</tag>
+        <tag>1.5.7</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
793: Fix more issues with DirectorySoftwareStatement serialisation

Use latest commons with fix to ensure `iss` field is visible in DirectorySoftwareStatement serialisation.
Also includes fix to add iss field to SoftwareStatement issued by the Directory Server.

Includes https://github.com/OpenBankingToolkit/openbanking-common/pull/140