### PR TITLE
Release 1.5.8 with 796: add matls checks to dcr code

### DIFF
--- a/forgerock-openbanking-directory-client/pom.xml
+++ b/forgerock-openbanking-directory-client/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.8</version>
+        <version>1.5.9-SNAPSHOT</version>
     </parent>
 
 </project>

--- a/forgerock-openbanking-directory-client/pom.xml
+++ b/forgerock-openbanking-directory-client/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.8-SNAPSHOT</version>
+        <version>1.5.8</version>
     </parent>
 
 </project>

--- a/forgerock-openbanking-directory-core/pom.xml
+++ b/forgerock-openbanking-directory-core/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.8</version>
+        <version>1.5.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-directory-core/pom.xml
+++ b/forgerock-openbanking-directory-core/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.8-SNAPSHOT</version>
+        <version>1.5.8</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-directory-sample/pom.xml
+++ b/forgerock-openbanking-directory-sample/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.8</version>
+        <version>1.5.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-directory-sample/pom.xml
+++ b/forgerock-openbanking-directory-sample/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.8-SNAPSHOT</version>
+        <version>1.5.8</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-directory-server/pom.xml
+++ b/forgerock-openbanking-directory-server/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.8</version>
+        <version>1.5.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-directory-server/pom.xml
+++ b/forgerock-openbanking-directory-server/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.8-SNAPSHOT</version>
+        <version>1.5.8</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Directory</name>
     <groupId>com.forgerock.openbanking.directory</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-    <version>1.5.8-SNAPSHOT</version>
+    <version>1.5.8</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -110,7 +110,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-directory.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-directory.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/OpenBankingToolkit-directory.git</url>
-        <tag>HEAD</tag>
+        <tag>1.5.8</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,9 @@
     </modules>
 
     <properties>
-        <ob-clients.version>1.2.9</ob-clients.version>
-        <ob-common.version>1.2.9</ob-common.version>
-        <ob-auth.version>1.1.8</ob-auth.version>
+        <ob-clients.version>1.2.10</ob-clients.version>
+        <ob-common.version>1.2.10</ob-common.version>
+        <ob-auth.version>1.1.9</ob-auth.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Directory</name>
     <groupId>com.forgerock.openbanking.directory</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-    <version>1.5.8</version>
+    <version>1.5.9-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -110,7 +110,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-directory.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-directory.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/OpenBankingToolkit-directory.git</url>
-        <tag>1.5.8</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
796: Add MATLS checks to DCR code

Common code needed to perform MATLS checks to ensure the MATLS transport
cert presented for registration and the software statement being used
for registration were issed to the same ApiClient (TPP)

Issue: https://github.com/ForgeCloud/ob-deploy/issues/796