### PR TITLE
45: use latest uk-datamodels with 3.1.8r5 swagger gen

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.2.4</version>
+        <version>1.2.5</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
@@ -45,9 +45,9 @@
     </modules>
 
     <properties>
-        <ob-clients.version>1.2.12</ob-clients.version>
-        <ob-common.version>1.2.12</ob-common.version>
-        <ob-auth.version>1.1.11</ob-auth.version>
+        <ob-clients.version>1.2.13</ob-clients.version>
+        <ob-common.version>1.2.13</ob-common.version>
+        <ob-auth.version>1.1.12</ob-auth.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/45