### PR TITLE
45: Release 1.5.12 and use fixed uk-datamodel for 3.1.8r5

### DIFF
--- a/forgerock-openbanking-directory-client/pom.xml
+++ b/forgerock-openbanking-directory-client/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.12-SNAPSHOT</version>
+        <version>1.5.12</version>
     </parent>
 
 </project>

--- a/forgerock-openbanking-directory-client/pom.xml
+++ b/forgerock-openbanking-directory-client/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.12</version>
+        <version>1.5.13-SNAPSHOT</version>
     </parent>
 
 </project>

--- a/forgerock-openbanking-directory-core/pom.xml
+++ b/forgerock-openbanking-directory-core/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.12-SNAPSHOT</version>
+        <version>1.5.12</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-directory-core/pom.xml
+++ b/forgerock-openbanking-directory-core/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.12</version>
+        <version>1.5.13-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-directory-sample/pom.xml
+++ b/forgerock-openbanking-directory-sample/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.12-SNAPSHOT</version>
+        <version>1.5.12</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-directory-sample/pom.xml
+++ b/forgerock-openbanking-directory-sample/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.12</version>
+        <version>1.5.13-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-directory-server/pom.xml
+++ b/forgerock-openbanking-directory-server/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.12-SNAPSHOT</version>
+        <version>1.5.12</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-directory-server/pom.xml
+++ b/forgerock-openbanking-directory-server/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.directory</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-        <version>1.5.12</version>
+        <version>1.5.13-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.2.5</version>
+        <version>1.2.6</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
@@ -45,9 +45,9 @@
     </modules>
 
     <properties>
-        <ob-clients.version>1.2.13</ob-clients.version>
-        <ob-common.version>1.2.13</ob-common.version>
-        <ob-auth.version>1.1.12</ob-auth.version>
+        <ob-clients.version>1.2.14</ob-clients.version>
+        <ob-common.version>1.2.14</ob-common.version>
+        <ob-auth.version>1.1.13</ob-auth.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Directory</name>
     <groupId>com.forgerock.openbanking.directory</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-    <version>1.5.12-SNAPSHOT</version>
+    <version>1.5.12</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -110,7 +110,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-directory.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-directory.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/OpenBankingToolkit-directory.git</url>
-        <tag>HEAD</tag>
+        <tag>1.5.12</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Directory</name>
     <groupId>com.forgerock.openbanking.directory</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-directory</artifactId>
-    <version>1.5.12</version>
+    <version>1.5.13-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -110,7 +110,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-directory.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-directory.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/OpenBankingToolkit-directory.git</url>
-        <tag>1.5.12</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
OBFundsConfirmationConsentResponse1Data uses OBExternalRequestStatus1Code rather than the StatusEnum
defined within the class.

Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/45